### PR TITLE
Add sync.py #1

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import os
+from os.path import basename
+import pyinotify
+
+dirname = "/home/redrield/Documents/Classroom"
+
+watchManager = pyinotify.WatchManager()
+
+mask = pyinotify.IN_DELETE | pyinotify.IN_MODIFY | pyinotify.IN_CREATE
+
+watchManager.add_watch(dirname, rec=True, mask=mask)
+
+
+def handler(ev):
+    os.system("""rclone sync {} "School Drive:/{}" """.format(dirname, basename(dirname)))
+
+
+notifier = pyinotify.Notifier(watchManager, handler)
+notifier.loop()

--- a/sync.py
+++ b/sync.py
@@ -4,7 +4,8 @@ import os
 from os.path import basename
 import pyinotify
 
-dirname = "/home/redrield/Documents/Classroom"
+dirname = "/home/redrield/Documents/Classroom" # Change directory to what you want here
+rcloneDriveName = "School Drive" # Change rclone drive to the one you've defined and you want to sync
 
 watchManager = pyinotify.WatchManager()
 
@@ -14,7 +15,7 @@ watchManager.add_watch(dirname, rec=True, mask=mask)
 
 
 def handler(ev):
-    os.system("""rclone sync {} "School Drive:/{}" """.format(dirname, basename(dirname)))
+    os.system("""rclone sync {} "{}:/{}" """.format(dirname, rcloneDriveName, basename(dirname)))
 
 
 notifier = pyinotify.Notifier(watchManager, handler)


### PR DESCRIPTION
This is a small script I've written to sync schoolwork from a local folder to google drive. I haven't gotten it to work with syncing the root drive, and it's only one way, but it's better than alternatives I've found. The script runs indefinitely, and the code to sync the folder is called through a pyinotify hook.

inotify-tools and rclone are required from Linux distro package managers, pyinotify is required from pip